### PR TITLE
ポップアップ表示の実装をメソッド化して、get/fetch(restApi)通信で共通使用

### DIFF
--- a/public/js/showSelectedPlan.js
+++ b/public/js/showSelectedPlan.js
@@ -860,41 +860,56 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
 //予定を見るからきたら、セレクトボックスの最初に表示されるプランの位置へ移動。新規登録から来たときは、そのプランの位置へ移動
 var firstShowPlan = window.firstShowPlan;
 var firstShowLat = firstShowPlan['country']['lat'];
-var firstShowLng = firstShowPlan['country']['lng']; //リレーション['plan_detail']の長さが0じゃなかったらその位置へ移動(長さが0ということはplanDetailテーブルにレコードがないということ)
+var firstShowLng = firstShowPlan['country']['lng'];
+
+function showPopups(planDetails, planInfo) {
+  for (var i = 0; i < planDetails.length; i++) {
+    var popup = L.popup({
+      closeOnClick: false,
+      autoClose: false
+    });
+    var content = planInfo.title + '<br>' + planDetails[i].name;
+
+    if (planDetails[i].dayToVisit) {
+      var date = planDetails[i].dayToVisit.split('-');
+      date = date[0] + '年' + date[1] + '月' + date[2] + '日';
+      content += '<br>' + '訪問日：' + date;
+    }
+
+    if (planDetails[i].timeToVisit) {
+      var time = planDetails[i].timeToVisit.split(':');
+      time = time[0] + '時' + time[1] + '分';
+      content += '<br>' + '予定時間；' + time;
+    }
+
+    if (planDetails[i].comment) {
+      content += '<br>' + '!コメント!' + '<br>' + planDetails[i].comment;
+    }
+
+    popup.setContent(content);
+    var marker = L.marker([Number(planDetails[i].latitude), Number(planDetails[i].longitude)]);
+    marker.bindPopup(popup);
+    marker.addTo(map);
+  } //選ばれた計画に対応するplanDetailテーブルにある最後のレコードを取得し、その緯度に表示移動
+
+
+  var lastDestination = planDetails[planDetails.length - 1];
+  var lastLatLng = [Number(lastDestination["latitude"]), Number(lastDestination["longitude"])];
+  map.setView(lastLatLng);
+} //リレーション['plan_detail']の長さが0じゃなかったらその位置へ移動(長さが0ということはplanDetailテーブルにレコードがないということ)
+
 
 if (firstShowPlan['plan_detail'].length === 0) {
   map.setView([firstShowLat, firstShowLng]);
 } else {
-  var firstShowPlanDetails = firstShowPlan['plan_detail'];
-  var detailLatLng = '';
+  var planDetails = firstShowPlan['plan_detail'];
+  var planInfo = firstShowPlan;
+  showPopups(planDetails, planInfo);
+} //selectボックスが変更されたときの処理
 
-  var _iterator = _createForOfIteratorHelper(firstShowPlanDetails),
-      _step;
-
-  try {
-    for (_iterator.s(); !(_step = _iterator.n()).done;) {
-      var firstShowPlanDetail = _step.value;
-      detailLatLng = [firstShowPlanDetail['latitude'], firstShowPlanDetail['longitude']]; //planDetailの目的地の緯度経度をまとめて1つに
-
-      var marker = L.marker(detailLatLng).addTo(map);
-    }
-  } catch (err) {
-    _iterator.e(err);
-  } finally {
-    _iterator.f();
-  }
-
-  map.setView(detailLatLng);
-}
 
 var selected = document.querySelector('[name="myPlans"]');
 var countryLatLng = {};
@@ -920,39 +935,7 @@ var moveToCountry = function moveToCountry(data) {
   if (planDetails.length === 0) {
     map.setView([countryLatLng["lat"], countryLatLng["lng"]]);
   } else {
-    for (var i = 0; i < planDetails.length; i++) {
-      var popup = L.popup({
-        closeOnClick: false,
-        autoClose: false
-      });
-      var content = planInfo.title + '<br>' + planDetails[i].name;
-
-      if (planDetails[i].dayToVisit) {
-        var date = planDetails[i].dayToVisit.split('-');
-        date = date[0] + '年' + date[1] + '月' + date[2] + '日';
-        content += '<br>' + '訪問日：' + date;
-      }
-
-      if (planDetails[i].timeToVisit) {
-        var time = planDetails[i].timeToVisit.split(':');
-        time = time[0] + '時' + time[1] + '分';
-        content += '<br>' + '予定時間；' + time;
-      }
-
-      if (planDetails[i].comment) {
-        content += '<br>' + '!コメント!' + '<br>' + planDetails[i].comment;
-      }
-
-      popup.setContent(content);
-      var marker = L.marker([Number(planDetails[i].latitude), Number(planDetails[i].longitude)]);
-      marker.bindPopup(popup);
-      marker.addTo(map);
-    } //選ばれた計画に対応するplanDetailテーブルにある最後のレコードを取得し、その緯度に表示移動
-
-
-    var lastDestination = planDetails[planDetails.length - 1];
-    var lastLatLng = [Number(lastDestination["latitude"]), Number(lastDestination["longitude"])];
-    map.setView(lastLatLng);
+    showPopups(planDetails, planInfo);
   }
 };
 

--- a/resources/js/showSelectedPlan.js
+++ b/resources/js/showSelectedPlan.js
@@ -3,20 +3,46 @@
     var firstShowLat = firstShowPlan['country']['lat'];
     var firstShowLng = firstShowPlan['country']['lng'];
 
+    function showPopups(planDetails, planInfo) {
+        for (let i = 0; i < planDetails.length; i++) {
+            var popup = L.popup({
+                closeOnClick: false,
+                autoClose: false
+            });
+            var content = planInfo.title + '<br>' + planDetails[i].name;
+                    if(planDetails[i].dayToVisit) {
+                        var date = planDetails[i].dayToVisit.split('-');
+                        date = date[0] + '年' + date[1] + '月' + date[2] + '日';
+                        content += '<br>' + '訪問日：' + date;
+                    }
+                    if(planDetails[i].timeToVisit) {
+                        var time = planDetails[i].timeToVisit.split(':');
+                        time = time[0] + '時' + time[1] + '分';
+                        content += '<br>' + '予定時間；' + time;
+                    }
+                    if(planDetails[i].comment) {
+                        content += '<br>' + '!コメント!' + '<br>' + planDetails[i].comment;
+                    }
+            popup.setContent(content);
+            var marker = L.marker([Number(planDetails[i].latitude), Number(planDetails[i].longitude)]);
+            marker.bindPopup(popup);
+            marker.addTo(map);
+        }
+        //選ばれた計画に対応するplanDetailテーブルにある最後のレコードを取得し、その緯度に表示移動
+        var lastDestination = planDetails[planDetails.length -1];
+        var lastLatLng = [Number(lastDestination["latitude"]), Number(lastDestination["longitude"])];
+        map.setView(lastLatLng);
+    }
+
     //リレーション['plan_detail']の長さが0じゃなかったらその位置へ移動(長さが0ということはplanDetailテーブルにレコードがないということ)
     if(firstShowPlan['plan_detail'].length === 0) {
         map.setView([firstShowLat, firstShowLng]);
     } else {
-    var firstShowPlanDetails = firstShowPlan['plan_detail'];
-    var detailLatLng = '';
-    for(let firstShowPlanDetail of firstShowPlanDetails) {
-        detailLatLng = [firstShowPlanDetail['latitude'], firstShowPlanDetail['longitude']]; //planDetailの目的地の緯度経度をまとめて1つに
-        var marker = L.marker(detailLatLng).addTo(map);
+        var planDetails = firstShowPlan['plan_detail'];
+        var planInfo = firstShowPlan;
+        showPopups(planDetails, planInfo);
     }
-    map.setView(detailLatLng);
-    }
-   
-
+   //selectボックスが変更されたときの処理
     var selected = document.querySelector('[name="myPlans"]');
     var countryLatLng = {};
     var planInfo = '';
@@ -38,37 +64,8 @@
         if(planDetails.length === 0) {
             map.setView([countryLatLng["lat"], countryLatLng["lng"]]);
         } else {
-            for (let i = 0; i < planDetails.length; i++) {
-                var popup = L.popup({
-                    closeOnClick: false,
-                    autoClose:false
-                });
-                var content = planInfo.title + '<br>' + planDetails[i].name;
-                if(planDetails[i].dayToVisit) {
-                    var date = planDetails[i].dayToVisit.split('-');
-                    date = date[0] + '年' + date[1] + '月' + date[2] + '日';
-                    content += '<br>' + '訪問日：' + date;
-                }
-                if(planDetails[i].timeToVisit) {
-                    var time = planDetails[i].timeToVisit.split(':');
-                    time = time[0] + '時' + time[1] + '分';
-                    content += '<br>' + '予定時間；' + time;
-                }
-                if(planDetails[i].comment) {
-                    content += '<br>' + '!コメント!' + '<br>' + planDetails[i].comment;
-                }
-                popup.setContent(content);
-
-                var marker = L.marker([Number(planDetails[i].latitude), Number(planDetails[i].longitude)]);
-                marker.bindPopup(popup);
-                marker.addTo(map);
-            }
-            //選ばれた計画に対応するplanDetailテーブルにある最後のレコードを取得し、その緯度に表示移動
-            var lastDestination = planDetails[planDetails.length -1];
-            var lastLatLng = [Number(lastDestination["latitude"]), Number(lastDestination["longitude"])];
-            map.setView(lastLatLng);
+            showPopups(planDetails, planInfo);
         }
-        
     };
     async function getData(url = '') {
         // 既定のオプションには * が付いています


### PR DESCRIPTION
ポップアップ表示の実装をメソッド化して、get/fetch(restApi)通信でshowMyPlan.blade.phpにアクセスしたときに共通使用できるようにした。
Route::get('showMyPlan', [MapController::class, 'showMyPlan'])->name('showMyPlan');
Route::get('/show_MyPlan/{id}', [ApiController::class, 'showSelectedPlan'])->middleware('auth:users');
でアクセスされたときに使用。
