### PR TITLE
旅行計画詳細をフォームで追加するときにフォーム内容が送信されるとポップアップの内容が変化する実装を追加

### DIFF
--- a/public/js/addPlanDetailByClick.js
+++ b/public/js/addPlanDetailByClick.js
@@ -20,9 +20,14 @@ function showForm(e) {
   //nowMarkerがなかったらマーカーを立てる処理(addFormでは2つ以上のマーカーを同時に立てられなくするため)
   if (nowMarker == '') {
     var lat = e.latlng.lat;
-    var lng = e.latlng.lng;
+    var lng = e.latlng.lng; //任意のアイコン
+    // var icon = L.icon({
+    //     iconUrl: 'public/images/icon.png', 
+    // });
+    // var marker = L.marker([lat, lng], { icon: icon });
+
     var marker = L.marker([lat, lng]);
-    var popup = L.popup({});
+    popup = L.popup({});
     var formContent = '<form class="fetchForm">' + '<input type="hidden" name="_token" value="' + csrf_token + '">' + '旅行地：' + '<input type="text" name="name">' + '<br>' + '訪問予定日：' + '<input type="date" name="dayToVisit">' + '<br>' + '予定時間：' + '<input type="time" name="timeToVisit">' + '<br>' + 'コメント' + '<input type="text" name="comment">' + '<br>' + '<input type="hidden" name="plan_id" value="' + selectedPlan.value + '">' + '<input type="hidden" name="lat" value="' + lat + '">' + '<input type="hidden" name="lng" value="' + lng + '">' + '<input type="button" value="送信" onclick="postFetch()" class="btn">' + '<input type="button" value="削除" onclick="deletePopup()" class="btn">' + '</form>';
     popup.setContent(formContent);
     marker.bindPopup(popup);
@@ -70,6 +75,14 @@ function showForm(e) {
 
       window.nowMarker = this;
     });
+  } else {
+    $(function () {
+      setInterval(function () {
+        $(".leaflet-marker-icon leaflet-zoom-animated leaflet-interactive").fadeOut(500).fadeIn(500);
+      }, 1000);
+    }); // alert('aaa');
+
+    alert('フォームポップアップは1つのみ表示可能です');
   }
 } //ポップアップの削除ボタンを押したときに、マーカーを削除
 

--- a/resources/js/addPlanDetailByClick.js
+++ b/resources/js/addPlanDetailByClick.js
@@ -11,8 +11,13 @@ function showForm(e) {
     if(nowMarker == ''){
         var lat = e.latlng.lat;
         var lng = e.latlng.lng;
+        //任意のアイコン
+        // var icon = L.icon({
+        //     iconUrl: 'public/images/icon.png', 
+        // });
+        // var marker = L.marker([lat, lng], { icon: icon });
         var marker = L.marker([lat, lng]);
-        var popup = L.popup({
+        popup = L.popup({
         });
         var formContent = '<form class="fetchForm">' +
             '<input type="hidden" name="_token" value="' + csrf_token + '">' +
@@ -72,6 +77,15 @@ function showForm(e) {
             }
             window.nowMarker = this;
         });
+    } else {
+        $(function(){
+            setInterval(function(){
+            $(".leaflet-marker-icon leaflet-zoom-animated leaflet-interactive").fadeOut(500).fadeIn(500);
+            },1000);
+            });
+            // alert('aaa');
+        alert('フォームポップアップは1つのみ表示可能です');
+      
     }
 }
 //ポップアップの削除ボタンを押したときに、マーカーを削除


### PR DESCRIPTION
旅行計画詳細をフォームで追加するときにフォーム内容が送信されるとポップアップの内容が変化する実装を追加
フォームが送信されるとfetch/post通信でDBに登録される。
登録されたら、ポップアップ内のフォーム内容が今送信した内容に変わる実装を追加。
さらに、フォームについてのポップアップは2個以上は同時に表示できないように変更。
フォームについてのポップアップを1つクリックした状態で、マップの他の場所をクリックするとアラートが出る。