### PR TITLE
旅行計画詳細をマップ上のフォームから登録する実装をマップ上に複数フォーム表示対応にする実装を追加

### DIFF
--- a/public/js/addPlanDetailByClick.js
+++ b/public/js/addPlanDetailByClick.js
@@ -119,11 +119,20 @@ postFetch = function postFetch(e) {
     content += '<br>' + '<input type="button" value="更新"  onclick="updatePlanDetail(event,' + registeredInfo.id + ')" class="updateBtn" class="bg-black" disabled>';
     content += '<br>' + '<input type="button" value="削除" id="deletePlanDetail" onclick="window.deletePlanDetail(' + registeredInfo.id + ')" class="btn">';
     content += '<br>' + '<input type="hidden" name="planDetail_id" value="' + registeredInfo.id + '">' + '</form>'; //ここまで追加
+    //ここから追加
 
-    formContent.remove(); // popup.setContent(content);
+    var lat = fetchForm.querySelector('input[name="lat"]').value;
+    lat = Number(lat);
+    var posted = markersOnDisplay[lat];
+    posted._popup._content = content; //ここから削除
+    //formContent.remove();
+    //popup.setContent(content);
+    //ここまで削除
+    //ここからjavascript見た目
 
-    window.postedPopupContent.innerText = content;
-    nowPlan[registeredInfo.id] = window.nowMarker;
+    window.postedPopupContent.innerHTML = content; //ここまで見た目
+
+    nowPlan[registeredInfo.id] = posted;
     window.nowMarker = '';
   })["catch"](function (error) {
     console.log(error);

--- a/resources/js/addPlanDetailByClick.js
+++ b/resources/js/addPlanDetailByClick.js
@@ -6,7 +6,7 @@ map.on('click', showForm);
 window.markersOnDisplay = {};
 window.nowMarker = '';
 window.fetchForm = '';
-// window.postedPopupContent = '';
+window.postedPopupContent = '';
 var popup = L.popup({
 });
 function showForm(e) {
@@ -65,7 +65,7 @@ postFetch = function(e){
     //eventオブジェクトで送信ボタンを押したフォームを送信
     var btn = e.currentTarget;
     fetchForm = btn.closest('.fetchForm');
-    // window.postedPopupContent = e.path[2];
+    window.postedPopupContent = e.path[2];
     // これだけでPOSTする際のBODYの値が定義できる
     let formData = new FormData(fetchForm);
     // 実際に値を見てみましょう
@@ -109,10 +109,17 @@ postFetch = function(e){
         content += '<br>' + '<input type="button" value="削除" id="deletePlanDetail" onclick="window.deletePlanDetail('+ registeredInfo.id + ')" class="btn">';
         content += '<br>' + '<input type="hidden" name="planDetail_id" value="' + registeredInfo.id + '">' + '</form>';
                     //ここまで追加
-        formContent.remove();
-        popup.setContent(content);
-        // window.postedPopupContent.innerText = content;
-        nowPlan[registeredInfo.id] = window.nowMarker;
+
+        //ここからleafletでポップアップ中身変更
+        var lat = fetchForm.querySelector('input[name="lat"]').value;
+        lat = Number(lat);
+        var posted = markersOnDisplay[lat];
+        posted._popup._content = content;
+        //ここまでleafletでポップアップ中身変更
+        //ここからjavascript見た目
+        window.postedPopupContent.innerHTML = content;
+        //ここまで見た目
+        nowPlan[registeredInfo.id] = posted;
         window.nowMarker = '';
     })
     .catch((error) => {


### PR DESCRIPTION
・旅行計画詳細をマップ上のフォームから登録する実装をマップ上に複数フォーム表示対応にする実装を追加
　　--addPlanDetailByClick.js
　　　68行目の  window.postedPopupContent = e.path[2];はイベントオブジェクトの中身を見ると、pathの中がdom構造になっていてこれの3つ目の要素がポップアップの中身を保持しているのでこれを変数に代入した。

・旅行計画詳細のフォームが複数表示されている状態でフォームの削除ボタンを押すとその押されたフォームを削除する実装を追加addPlanDetailByClick.js
　　--addPlanDetailByClick.jsのdeletePopupメソッド
　　　markersOnDisplayという連想配列を生成し、これにそのフォームの緯度をキーとして追加。
　　　deletePopupメソッドではメソッドの引数にeventオブジェクトをとるようにした。
