### PR TITLE
カレンダーに旅行計画が未表示時のみ旅行計画を表示させる実装を追加

### DIFF
--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -12,18 +12,27 @@ var showDate = new Date(today.getFullYear(), today.getMonth(), 1); // 初期表�
 window.onload = function () {
   showProcess(today, calendar);
   window.showTravelPlans();
+  calendar.setAttribute('class', 'clicked');
 }; // 前の月表示
 
 
 window.prev = function () {
   showDate.setMonth(showDate.getMonth() - 1);
   showProcess(showDate);
+
+  if (calendar.classList.contains('clicked')) {
+    calendar.classList.remove('clicked');
+  }
 }; // 次の月表示
 
 
 window.next = function () {
   showDate.setMonth(showDate.getMonth() + 1);
   showProcess(showDate);
+
+  if (calendar.classList.contains('clicked')) {
+    calendar.classList.remove('clicked');
+  }
 }; // カレンダー表示
 
 
@@ -120,6 +129,15 @@ window.showTravelPlans = function () {
 };
 
 var btn = document.querySelector('#button');
-btn.onclick = window.showTravelPlans;
+var calendar = document.getElementById('calendar'); //clickedで旅行計画がカレンダーに表示済みか判断して複数回表示されるのを防ぐ
+
+window.btnClick = function () {
+  if (!calendar.classList.contains('clicked')) {
+    calendar.setAttribute('class', 'clicked');
+    window.showTravelPlans();
+  }
+};
+
+btn.onclick = window.btnClick;
 /******/ })()
 ;

--- a/resources/js/calendar.js
+++ b/resources/js/calendar.js
@@ -8,17 +8,24 @@ var showDate = new Date(today.getFullYear(), today.getMonth(), 1);
 window.onload = function () {
     showProcess(today, calendar);
     window.showTravelPlans();
+    calendar.setAttribute('class', 'clicked');
 };
 // 前の月表示
 window.prev = function(){
     showDate.setMonth(showDate.getMonth() - 1);
     showProcess(showDate);
+    if(calendar.classList.contains('clicked')){
+        calendar.classList.remove('clicked');
+    }
 }
 
 // 次の月表示
 window.next = function(){
     showDate.setMonth(showDate.getMonth() + 1);
     showProcess(showDate);
+    if(calendar.classList.contains('clicked')){
+        calendar.classList.remove('clicked');
+    }
 }
 
 // カレンダー表示
@@ -111,4 +118,13 @@ window.showTravelPlans = function () {
     });
 };
 var btn = document.querySelector('#button');
-btn.onclick = window.showTravelPlans;
+var calendar = document.getElementById('calendar');
+//clickedで旅行計画がカレンダーに表示済みか判断して複数回表示されるのを防ぐ
+window.btnClick = function(){
+    if(!(calendar.classList.contains('clicked'))){
+        calendar.setAttribute('class', 'clicked');
+        window.showTravelPlans();
+    }
+}
+btn.onclick = window.btnClick;
+


### PR DESCRIPTION
カレンダーに旅行計画が表示済みか・未表示化をクラス名clickedで判断し、未表示時のみ旅行計画が表示される実装を追加。
これによりカレンダーに同じ旅行計画が複数表示されるのを防ぐ。