### PR TITLE
公開旅行計画詳細モーダルのキャプションタグの位置を上部中央に変更

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -13751,7 +13751,9 @@ header a[class="title"] {
     margin-top: 3%;
     color: #6495ed;
     font-weight: 600;
-    font-size: 20px
+    font-size: 20px;
+    text-align: center;
+    caption-side: top;
 }
 .position_show table td{
     border-color: #fff;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -511,7 +511,9 @@ header a[class="title"] {
     margin-top: 3%;
     color: #6495ed;
     font-weight: 600;
-    font-size: 20px
+    font-size: 20px;
+    text-align: center;
+    caption-side: top;
 }
 .position_show table td{
     border-color: #fff;


### PR DESCRIPTION
・countrysSharedPlan.blade.php内でコンパイルしている
・sharedPlan.jsのキャプションタグの位置をapp.cssで上部中央に変更した。